### PR TITLE
Create LoginActivity for Spotify login

### DIFF
--- a/bopshareapp/app/src/main/AndroidManifest.xml
+++ b/bopshareapp/app/src/main/AndroidManifest.xml
@@ -2,8 +2,8 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.example.bopshareapp">
 
-    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/>
-    <uses-permission android:name="android.permission.INTERNET"/>
+    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
+    <uses-permission android:name="android.permission.INTERNET" />
 
     <application
         android:name=".BopshareApplication"
@@ -15,10 +15,12 @@
         android:theme="@style/Theme.BopShareApp">
         <activity
             android:name=".MainActivity"
+            android:exported="true" />
+        <activity
+            android:name=".LoginActivity"
             android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
-
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
@@ -32,7 +34,6 @@
         <meta-data
             android:name="com.parse.CLIENT_KEY"
             android:value="@string/back4app_client_key" />
-
     </application>
 
 </manifest>

--- a/bopshareapp/app/src/main/java/com/example/bopshareapp/LoginActivity.kt
+++ b/bopshareapp/app/src/main/java/com/example/bopshareapp/LoginActivity.kt
@@ -1,0 +1,53 @@
+package com.example.bopshareapp
+
+import android.content.Intent
+import androidx.appcompat.app.AppCompatActivity
+import android.os.Bundle
+import android.util.Log
+import android.widget.Button
+import com.spotify.sdk.android.auth.AccountsQueryParameters
+import com.spotify.sdk.android.auth.AuthorizationClient
+import com.spotify.sdk.android.auth.AuthorizationRequest
+import com.spotify.sdk.android.auth.AuthorizationResponse
+
+class LoginActivity : AppCompatActivity() {
+
+    private val CLIENT_ID = "ce0aa4e253dc42b8a3ec6a9ed8ff0c1b"
+    private val REDIRECT_URI = "bop-share-app-login://callback"
+    private val REQUEST_CODE = 1337
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_login)
+
+        findViewById<Button>(R.id.btn_login).setOnClickListener() {
+            var builder = AuthorizationRequest.Builder(CLIENT_ID, AuthorizationResponse.Type.TOKEN, REDIRECT_URI)
+            builder.setScopes(Array<String>(1){"streaming"})
+            var request = builder.build()
+            AuthorizationClient.openLoginActivity(this,REQUEST_CODE,request)
+        }
+    }
+
+    override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
+        super.onActivityResult(requestCode, resultCode, data)
+        if (requestCode == REQUEST_CODE) {
+            var response = AuthorizationClient.getResponse(resultCode, data)
+            var type = response.type
+            if (type.equals(AuthorizationResponse.Type.TOKEN)) {
+                Log.d("MainActivity", "User logged in successfully")
+                var token = response.accessToken
+                goToMainActivity()
+            } else if (type.equals(AuthorizationResponse.Type.ERROR)) {
+                Log.e("MainActivity", "Error logging in user")
+            } else {
+                Log.d("MainActivity", "Auth flow cancelled")
+            }
+        }
+    }
+
+    private fun goToMainActivity() {
+        val i = Intent(this@LoginActivity, MainActivity::class.java)
+        startActivity(i)
+        finish()
+    }
+}

--- a/bopshareapp/app/src/main/java/com/example/bopshareapp/MainActivity.kt
+++ b/bopshareapp/app/src/main/java/com/example/bopshareapp/MainActivity.kt
@@ -1,5 +1,6 @@
 package com.example.bopshareapp
 
+import android.content.Intent
 import androidx.appcompat.app.AppCompatActivity
 import android.os.Bundle
 import android.util.Log
@@ -11,6 +12,11 @@ import com.spotify.android.appremote.api.SpotifyAppRemote
 import com.spotify.protocol.client.Subscription
 import com.spotify.protocol.types.PlayerState
 import com.spotify.protocol.types.Track
+import com.spotify.sdk.android.auth.AccountsQueryParameters.ACCESS_TOKEN
+import com.spotify.sdk.android.auth.AccountsQueryParameters.ERROR
+import com.spotify.sdk.android.auth.AuthorizationClient
+import com.spotify.sdk.android.auth.AuthorizationRequest
+import com.spotify.sdk.android.auth.AuthorizationResponse
 
 class MainActivity : AppCompatActivity() {
 
@@ -21,6 +27,7 @@ class MainActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_main)
+
         val firstObject = ParseObject("FirstClass")
         firstObject.put("message", "Hey ! First message from android. Parse is now connected")
         firstObject.saveInBackground {

--- a/bopshareapp/app/src/main/res/layout/activity_login.xml
+++ b/bopshareapp/app/src/main/res/layout/activity_login.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context=".LoginActivity">
+
+    <Button
+        android:id="@+id/btn_login"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="Login with Spotify"
+        android:textSize="25sp"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/bopshareapp/app/src/main/res/layout/activity_main.xml
+++ b/bopshareapp/app/src/main/res/layout/activity_main.xml
@@ -4,7 +4,6 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:backgroundTint="#00FFFFFF"
     tools:context=".MainActivity">
 
     <Button


### PR DESCRIPTION
Create LoginActivity to login via Spotify. Allows more flexibility in retrieving user information like favorite songs, genres, playlists, etc. Simple single sign-on setup with room for adding more user details up front later. Login persists across sessions.