### PR TITLE
Create Parse User with Spotify account details

### DIFF
--- a/bopshareapp/app/build.gradle
+++ b/bopshareapp/app/build.gradle
@@ -47,6 +47,8 @@ dependencies {
     implementation files('../../spotify-app-remote-release-0.7.2.aar')
     implementation "com.google.code.gson:gson:2.8.5"
 
+    implementation("com.android.volley:volley:1.2.1")
+
     testImplementation 'junit:junit:4.13.2'
     androidTestImplementation 'androidx.test.ext:junit:1.1.3'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'

--- a/bopshareapp/app/src/main/java/com/example/bopshareapp/BopshareApplication.kt
+++ b/bopshareapp/app/src/main/java/com/example/bopshareapp/BopshareApplication.kt
@@ -12,6 +12,6 @@ class BopshareApplication : Application() {
                 .clientKey(getString(R.string.back4app_client_key))
                 .server(getString(R.string.back4app_server_url))
                 .build()
-        );
+        )
     }
 }

--- a/bopshareapp/app/src/main/java/com/example/bopshareapp/LoginActivity.kt
+++ b/bopshareapp/app/src/main/java/com/example/bopshareapp/LoginActivity.kt
@@ -1,14 +1,20 @@
 package com.example.bopshareapp
 
 import android.content.Intent
+import android.content.SharedPreferences
 import androidx.appcompat.app.AppCompatActivity
 import android.os.Bundle
 import android.util.Log
-import android.widget.Button
-import com.spotify.sdk.android.auth.AccountsQueryParameters
+import com.android.volley.RequestQueue
+import com.google.gson.Gson
+import com.parse.*
 import com.spotify.sdk.android.auth.AuthorizationClient
 import com.spotify.sdk.android.auth.AuthorizationRequest
 import com.spotify.sdk.android.auth.AuthorizationResponse
+import okhttp3.*
+import java.io.IOException
+import org.json.JSONObject
+import org.json.JSONArray
 
 class LoginActivity : AppCompatActivity() {
 
@@ -16,21 +22,13 @@ class LoginActivity : AppCompatActivity() {
     private val REDIRECT_URI = "bop-share-app-login://callback"
     private val REQUEST_CODE = 1337
 
+    private val CURRENT_USER_PROFILE_URL = "https://api.spotify.com/v1/me"
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_login)
 
-        var builder = AuthorizationRequest.Builder(CLIENT_ID, AuthorizationResponse.Type.TOKEN, REDIRECT_URI)
-        builder.setScopes(Array<String>(1){"streaming"})
-        var request = builder.build()
-        AuthorizationClient.openLoginActivity(this,REQUEST_CODE,request)
-
-        findViewById<Button>(R.id.btn_login).setOnClickListener() {
-            var builder = AuthorizationRequest.Builder(CLIENT_ID, AuthorizationResponse.Type.TOKEN, REDIRECT_URI)
-            builder.setScopes(Array<String>(1){"streaming"})
-            var request = builder.build()
-            AuthorizationClient.openLoginActivity(this,REQUEST_CODE,request)
-        }
+        loginViaSpotify()
     }
 
     override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
@@ -39,18 +37,86 @@ class LoginActivity : AppCompatActivity() {
             var response = AuthorizationClient.getResponse(resultCode, data)
             var type = response.type
             if (type.equals(AuthorizationResponse.Type.TOKEN)) {
-                Log.d("MainActivity", "User logged in successfully")
-                var token = response.accessToken
-                goToMainActivity()
+                Log.d("LoginActivity", "User logged into Spotify successfully")
+                val token = response.accessToken
+                // Request Spotify profile of current user
+                var client = OkHttpClient()
+                val request = Request.Builder()
+                    .addHeader("Authorization", "Bearer $token")
+                    .url(CURRENT_USER_PROFILE_URL)
+                    .build()
+                client.newCall(request).enqueue(object : Callback {
+                    override fun onFailure(call: Call, e: IOException) {
+                        e.printStackTrace()
+                    }
+
+                    override fun onResponse(call: Call, response: Response) {
+                        response.use {
+                            if (!response.isSuccessful) throw IOException("Unexpected code $response")
+                            val responseBody = JSONObject(response.body()!!.string())
+                            var username = responseBody.getString("display_name")
+                            var spotifyId = responseBody.getString("id")
+                            Log.d("LoginActivity", "Retrieved Spotify account info for $username")
+                            // Use Spotify profile to login or sign up ParseUser
+                            if (ParseUser.getCurrentUser() != null && ParseUser.getCurrentUser().username.equals(username)) {
+                                ParseUser.getCurrentUser().put("accessToken",token)
+                            } else {
+                                loginUser(username, spotifyId, spotifyId, token)
+                            }
+                            goToMainActivity()
+                        }
+                    }
+                })
             } else if (type.equals(AuthorizationResponse.Type.ERROR)) {
-                Log.e("MainActivity", "Error logging in user")
+                var error = response.error
+                Log.e("LoginActivity", error)
             } else {
-                Log.d("MainActivity", "Auth flow cancelled")
+                Log.d("LoginActivity", "Auth flow cancelled")
             }
         }
     }
 
-    fun loginViaSpotify() {
+    private fun signUpUser(username: String,
+                           password: String,
+                           spotifyId: String,
+                           accessToken: String) {
+        // Create the ParseUser
+        val user = ParseUser()
+
+        // Set fields for the user to be created
+        user.setUsername(username)
+        user.setPassword(password)
+        user.put("accessToken", accessToken)
+        user.put("spotifyId", spotifyId)
+
+        user.signUpInBackground { e ->
+            if (e == null) {
+                // User has successfully created a new account
+                Log.d("LoginActivity", "Successfully created ParseUser")
+            } else {
+                e.printStackTrace()
+            }
+        }
+    }
+
+    private fun loginUser(username: String,
+                          password: String,
+                          spotifyId: String,
+                          accessToken: String) {
+        ParseUser.logInInBackground(username, password, ({ user, e ->
+            if (user != null) {
+                Log.d("LoginActivity", "Successfully logged in Parse User")
+                ParseUser.getCurrentUser().put("token",accessToken)
+            } else {
+                e.printStackTrace()
+            }})
+        )
+        if (ParseUser.getCurrentUser() == null) {
+            signUpUser(username,password,spotifyId,accessToken)
+        }
+    }
+
+    private fun loginViaSpotify() {
         var builder = AuthorizationRequest.Builder(CLIENT_ID, AuthorizationResponse.Type.TOKEN, REDIRECT_URI)
         builder.setScopes(Array<String>(1){"streaming"})
         var request = builder.build()


### PR DESCRIPTION
Create basic ParseUser including Spotify username and access token to make HTTP requests to Spotify API.